### PR TITLE
Ask for confirmation if receiver address is not the user address

### DIFF
--- a/src/constants/tokens.js
+++ b/src/constants/tokens.js
@@ -180,7 +180,7 @@ const UBI_TOKEN = {
   typeId: 6,
   icon: 'https://raw.githubusercontent.com/rsksmart/rsk-contract-metadata/master/images/ubi.png',
   30: { symbol: 'rUBI', address: '0x70566d8541beabe984c8babf8a816ed908514ba8', decimals: 18 },
-  31: { symbol: 'rUBI', address: '0x1c85316116131133cf6fdb0cde836b23035ea775', decimals: 18 },
+  31: { symbol: 'rKovUBI', address: '0x1c85316116131133cf6fdb0cde836b23035ea775', decimals: 18 },
   1: { symbol: 'UBI', address: '0xdd1ad9a21ce722c151a836373babe42c868ce9a4', decimals: 18 },
   42: { symbol: 'UBI', address: '0xddade19b13833d1bf52c1fe1352d41a8dd9fe8c9', decimals: 18 },
 }


### PR DESCRIPTION
We previously didn't allowed claims when the receiver address was not the user, this was donde to avoid sending it to a wrong address
A user sent funds directly to their exchange, we do want to allow this kind of behaviour, so we added a modal asking for confirmations when sending to another address


https://user-images.githubusercontent.com/3655076/128203161-7791cb67-e57a-4113-8afa-f9600eadef6d.mov

