### PR TITLE
fix(26): Execute resetForm method when the transaction is successful.

### DIFF
--- a/src/components/crossForm/CrossForm.vue
+++ b/src/components/crossForm/CrossForm.vue
@@ -640,6 +640,7 @@ export default {
           }
 
           data.$emit('newTransaction', transaction)
+          data.resetForm()
         })
         .catch(err => {
           data.showSpinner = false


### PR DESCRIPTION
Fix #26 