### PR TITLE
Fix v2UpdateBlock rskMainnet, watch transactiont at TransactionRow

### DIFF
--- a/src/components/transactions/TransactionRow.vue
+++ b/src/components/transactions/TransactionRow.vue
@@ -272,6 +272,13 @@ export default {
       if (!this.fromNetwork.isEth) return
       this.refreshStep()
     },
+    transaction() {
+      this.currentStep = this.transaction.currentStep || 0
+      this.txDataHash = NULL_HASH
+      this.loading = false
+      this.error = ''
+      this.refreshStep()
+    },
   },
   created() {
     this.refreshStep()

--- a/src/constants/networks.js
+++ b/src/constants/networks.js
@@ -62,7 +62,7 @@ export const RSK_MAINNET_CONFIG = {
   explorerTokenTab: '?__tab=tokens%20transfers',
   secondsPerBlock: 30,
   rpc: 'https://public-node.rsk.co',
-  v2UpdateBlock: 3642292,
+  v2UpdateBlock: 3540341,
   feePercentageDivider: 10_000,
   crossToNetwork: ETH_CONFIG,
   isRsk: true,


### PR DESCRIPTION
v2UpdateBlock was incorrect as the block showed by the explorer is not the creation address https://github.com/rsksmart/rsk-explorer/issues/131

Searching for a transaction worked fine the first time, but if you run a second search with another transaction the status was not updated. Added a watcher and reset the variables to fix this issue