### PR TITLE
fix: Added new emits when is loading and is failed to NFTForm Component

### DIFF
--- a/src/components/nftForm/NFTForm.vue
+++ b/src/components/nftForm/NFTForm.vue
@@ -71,7 +71,7 @@ export default {
       required: true,
     },
   },
-  emits: ['onSuccess'],
+  emits: ['onSuccess', 'onLoading', 'onFailed'],
   data() {
     return {
       sharedState: store.state,
@@ -107,6 +107,7 @@ export default {
           },
         })
         this.isLoading = false
+        this.$emit('onFailed')
         return
       }
       try {
@@ -123,6 +124,7 @@ export default {
         this.isLoading = false
       } catch (jsonError) {
         this.isLoading = false
+        this.$emit('onFailed')
         this.$modal.value.showModal({
           type: 'error',
           options: { modalProps: { message: jsonError.message, title: 'Error on Metadata info' } },
@@ -133,6 +135,7 @@ export default {
       const web3 = this.sharedState.web3
       const erc721 = new web3.eth.Contract(SIDE_NFT_TOKEN, this.nftContractAddress)
       this.isLoading = true
+      this.$emit('onLoading')
 
       const [tokenURIError, tokenURI] = await asyncTryCatch(
         erc721.methods.tokenURI(this.tokenId).call,
@@ -153,6 +156,7 @@ export default {
           },
         })
         this.isLoading = false
+        this.$emit('onFailed')
         return
       }
       if (!tokenURIError && tokenURI) {

--- a/src/components/nftForm/NFTWrapper.vue
+++ b/src/components/nftForm/NFTWrapper.vue
@@ -3,7 +3,12 @@
     <div class="nft-wrapper container p-5 mt-5">
       <div class="row">
         <div class="col-md-12 p-2">
-          <NFTForm :origin-network="originNetwork" @onSuccess="handleOnSuccess" />
+          <NFTForm
+            :origin-network="originNetwork"
+            @onSuccess="handleOnSuccess"
+            @onLoading="handleOnLoading"
+            @onFailed="handleOnFailed"
+          />
         </div>
         <div v-if="displayInformation" class="col-md-12 p-2">
           <NFTViewInformation :metadata="metadata"></NFTViewInformation>
@@ -99,6 +104,21 @@ export default {
     },
   },
   methods: {
+    resetState() {
+      this.displayInformation = false
+      this.metadata = {}
+      this.web3Contract = null
+      this.nftContractAddress = ''
+      this.tokenId = ''
+      this.isApproved = false
+      this.loadedInfo = false
+    },
+    handleOnLoading() {
+      this.resetState()
+    },
+    handleOnFailed() {
+      this.resetState()
+    },
     handleOnSuccess({ metadata, web3Contract, nftContractAddress, tokenId, isApproved }) {
       this.metadata = metadata
       this.displayInformation = true

--- a/src/modules/transactions/transactions.service.js
+++ b/src/modules/transactions/transactions.service.js
@@ -58,7 +58,7 @@ export class TransactionService {
   }
 
   async getTransactions(accountAddress, networkIds, tokenTypes, { limit, offset }) {
-    const transactionIncludeAddress = (transaction, accountAddress) => {
+    const transactionIncludeAddress = transaction => {
       const addressLowerCase = accountAddress.toLowerCase()
       if (Array.isArray(transaction.accountsAddresses)) {
         return transaction.accountsAddresses.includes(addressLowerCase)


### PR DESCRIPTION
fix: Removed unnecessary param to transactionIncludeAddress function

Signed-off-by: Jonathan Huamani <jonathan.huamani@iovlabs.org>

### Fix Wrong chain on cross back

When the network change, after to do a NFT cross, the old instances are not preserved.

### Description

- fix: Added new emits on NFTForm component when the getInfo is loading and failed
- fix: Removed unnecessary param to transactionIncludeAddress function

### How to Test

- Config your `.env` file
- Run the server

#### Case 1

1. Run the server
```shell
$~ npm run serve
```

2. Click on NFT

__Expected Result__
- The nft green block should change

3. Complete the NFT information
4. Click on Cross NFT
5. Change your origin network
6. Claim your token 
7. Send the token claimed to the first network


### Checklist
- [x] Lint is clean `npm run lint`
- [x] Prettier is passing `npm run prettier`
