### PR TITLE
Feature/error value when crossing binance

### DIFF
--- a/src/components/crossForm/CrossForm.vue
+++ b/src/components/crossForm/CrossForm.vue
@@ -6,15 +6,9 @@
         <div class="text-center  col-sm-2">
           <label class="tokenAddress-label" for="originNetwork">Origin Network</label>
           <div class="form-group">
-            <input
-              id="originNetwork"
-              type="text"
-              name="originNetwork"
-              class="form-control-plaintext text-center originNetwork"
-              :class="{ disabled: disabled }"
-              readonly
-              :value="originNetwork?.name"
-            />
+            <span class="originNetwork">
+              {{ originNetwork?.name }}
+            </span>
           </div>
         </div>
 
@@ -104,15 +98,9 @@
         <div class="text-center  col-sm-2">
           <label class="tokenAddress-label" for="destinationNetwork">Destination Network</label>
           <div class="form-group">
-            <input
-              id="destinationNetwork"
-              type="text"
-              name="destinationNetwork"
-              class="form-control-plaintext text-center destinationNetwork"
-              :class="{ disabled: disabled }"
-              readonly
-              :value="destinationNetwork?.name"
-            />
+            <span class="destinationNetwork">
+              {{ destinationNetwork?.name }}
+            </span>
           </div>
         </div>
 
@@ -631,7 +619,7 @@ export default {
     setClaimCost() {
       const { currentConfig: { isRsk } = {} } = this.sharedState
       const web3 = isRsk ? this.sharedState.sideWeb3 : this.sharedState.rskWeb3
-      const networkConf = isRsk ? this.sharedState.rskConfig : this.sharedState.sideConfg
+      const networkConf = isRsk ? this.sharedState.rskConfig : this.sharedState.sideConfig
       web3.eth.getGasPrice().then(gasPrice => {
         const costInWei = new BigNumber(ESTIMATED_GAS_AVG).multipliedBy(gasPrice)
         this.claimCost = `${costInWei.shiftedBy(-18).toString()} ${networkConf?.mainToken?.symbol}`

--- a/src/components/crossForm/CrossForm.vue
+++ b/src/components/crossForm/CrossForm.vue
@@ -621,8 +621,12 @@ export default {
       const web3 = isRsk ? this.sharedState.sideWeb3 : this.sharedState.rskWeb3
       const networkConf = isRsk ? this.sharedState.rskConfig : this.sharedState.sideConfig
       web3.eth.getGasPrice().then(gasPrice => {
-        const costInWei = new BigNumber(ESTIMATED_GAS_AVG).multipliedBy(gasPrice)
-        this.claimCost = `${costInWei.shiftedBy(-18).toString()} ${networkConf?.mainToken?.symbol}`
+        const costInWei = new BigNumber(ESTIMATED_GAS_AVG)
+          .multipliedBy(gasPrice)
+          .shiftedBy(-18)
+          .toPrecision(6)
+          .toString()
+        this.claimCost = `${costInWei} ${networkConf?.mainToken?.symbol}`
       })
     },
   },


### PR DESCRIPTION
### Fix wrong network symbol on binance

Fixed missed symbol on side network and change the claim cost significant precision

### Description

- Fix: renamed the sideConfig variable to display the side symbol correctly
- Feat: Change the origin and destination network container name to support the long network's name

### How to Test

- Config your `.env` file
- Run the server

#### Case 1

1. Run the server
```shell
$~ npm run serve
```

2. Change to Binance Network

__Expected Result__
- Should display the correct claim cost with the destination symbol

### Checklist
- [x] Lint is clean `npm run lint`
- [x] Prettier is passing `npm run prettier`
