### PR TITLE
Allow switch network

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -21,3 +21,10 @@ export function isEmpty(value) {
       return false
   }
 }
+
+export function numToHex(value) {
+  if (typeof value === 'number') {
+    return `0x${value.toString(16)}`
+  }
+  return value
+}


### PR DESCRIPTION

### Allow switch network from UI

Now you can switch the network from the UI, and if you don't have this network in your wallet, this request to add the network.

### Description

- New button to switch between origin and destination network (only Metamask)
- Request to add the network to your wallet if this doesn't exist (only Metamask)

### How to Test

- Config your `.env` file
- Run the server

#### Case 1

1. Run the server
```shell
$~ npm run serve
```

2. Connect your wallet
3. Select Metamask

__Expected Result__
- Should display "Switch Network" button in the page header near to destination network

4. Click on "Switch Network"

__Expected Result__
- Should display Metamask modal asking if you allow changing the network
- If you don't have the network in your wallet, should display a Metamask modal asking if you want to add this network to your wallet.

5. Accept

__Expected Result__
- Should swap the origin and destination networks

### Checklist
- [x] Lint is clean `npm run lint`
- [x] Prettier is passing `npm run prettier`
