### PR TITLE
feat: Moved conditional to get network config on claim cost

### DIFF
--- a/src/components/crossForm/CrossForm.vue
+++ b/src/components/crossForm/CrossForm.vue
@@ -619,7 +619,7 @@ export default {
     setClaimCost() {
       const { currentConfig: { isRsk } = {} } = this.sharedState
       const web3 = isRsk ? this.sharedState.sideWeb3 : this.sharedState.rskWeb3
-      const networkConf = isRsk ? this.sharedState.rskConfig : this.sharedState.sideConfig
+      const networkConf = isRsk ? this.sharedState.sideConfig : this.sharedState.rskConfig
       web3.eth.getGasPrice().then(gasPrice => {
         const costInWei = new BigNumber(ESTIMATED_GAS_AVG)
           .multipliedBy(gasPrice)


### PR DESCRIPTION
### Fixed error on wrong currency symbol

### Description

- Moved conditional to return rskConfig instead of sideConfig

### Checklist
- [x] Lint is clean `npm run lint`
- [x] Prettier is passing `npm run prettier`
