### PR TITLE
feat: Added modal to allow switch network when try to claim in wrong …

### DIFF
--- a/src/components/transactions/mixins/TransactionRowMixin.js
+++ b/src/components/transactions/mixins/TransactionRowMixin.js
@@ -11,6 +11,7 @@ import ERC20TokenTransaction from '@/modules/transactions/transactionsTypes/ERC2
 import ERC721NFTTransaction from '@/modules/transactions/transactionsTypes/ERC721NFTTransaction'
 import { decodeCrossEvent } from '@/utils/decodeEvents'
 import { findNetworkByChainId } from '@/constants/networks'
+import WrongNetwork from '@/components/transactions/modals/WrongNetwork'
 
 const DEFAULT_COPY_ICON = 'far fa-clipboard'
 
@@ -19,7 +20,7 @@ export default {
     Modal,
     VotingInfo,
   },
-  inject: ['$services'],
+  inject: ['$services', '$modal'],
   props: {
     transaction: {
       type: Object,
@@ -331,8 +332,13 @@ export default {
         return
       }
       if (sharedState.currentConfig.networkId !== this.toNetwork.networkId) {
-        data.connectionProblem = `Wrong network. To claim this tokens you need to connect your wallet to ${data.toNetwork.name}`
-        data.showConnectionProblemModal = true
+        this.$modal.value.showModal({
+          type: 'custom',
+          options: {
+            customModalComponent: WrongNetwork,
+            modalProps: { networkConfig: this.toNetwork },
+          },
+        })
         return
       }
       if (

--- a/src/components/transactions/modals/WrongNetwork.vue
+++ b/src/components/transactions/modals/WrongNetwork.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="bg-white p-2 rounded-sm">
+    <div class="modal-header">
+      <h4 class="m-0"><i class="fas fa-exclamation-triangle text-warning"></i> Wrong Network</h4>
+    </div>
+    <div class="modal-body">
+      <p>To claim this tokens you need to connect your wallet to {{ networkConfig.name }}</p>
+      <p v-if="errorMessage" class="text-danger">{{ errorMessage }}</p>
+      <div class="mt-4 text-center">
+        <button class="btn btn-primary mx-2" :disabled="loading" @click="handleSwitchNetwork">
+          <span
+            v-if="loading"
+            class="spinner-border spinner-border-sm"
+            role="status"
+            aria-hidden="true"
+          ></span>
+          Change to {{ networkConfig.name }}
+        </button>
+        <button class="btn btn-info mx-2" :disabled="loading" @click="handleKeepCurrentNetwork">
+          <span
+            v-if="loading"
+            class="spinner-border spinner-border-sm"
+            role="status"
+            aria-hidden="true"
+          ></span>
+          Keep in {{ networkConfig.crossToNetwork.name }}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { numToHex } from '@/utils/helpers'
+import { store } from '@/store'
+
+export default {
+  name: 'WrongNetwork',
+  props: {
+    networkConfig: {
+      type: Object,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      sharedState: store.state,
+      loading: false,
+      errorMessage: '',
+    }
+  },
+  methods: {
+    handleKeepCurrentNetwork() {
+      this.$parent.handleCloseModal()
+    },
+    async handleAddNetwork(networkConfig) {
+      try {
+        const chainId = numToHex(networkConfig.networkId)
+        await window.ethereum.request({
+          method: 'wallet_addEthereumChain',
+          params: [
+            {
+              chainId,
+              chainName: networkConfig.name,
+              nativeCurrency: {
+                name: networkConfig.mainToken.name,
+                symbol: networkConfig.mainToken.symbol,
+                decimals: networkConfig.mainToken.decimals,
+              },
+              rpcUrls: [networkConfig.rpc],
+            },
+          ],
+        })
+        this.loading = false
+        this.$parent.handleCloseModal()
+      } catch (error) {
+        this.loading = false
+        this.errorMessage = error.message
+      }
+    },
+    async handleSwitchNetwork() {
+      this.loading = true
+      this.errorMessage = ''
+      try {
+        const chainId = numToHex(this.networkConfig.networkId)
+        await window.ethereum.request({
+          method: 'wallet_switchEthereumChain',
+          params: [{ chainId }],
+        })
+        this.loading = false
+        this.$parent.handleCloseModal()
+      } catch (error) {
+        if (error.code === 4902) {
+          await this.handleAddNetwork(this.networkConfig)
+        } else {
+          this.loading = false
+          this.errorMessage = error.message
+        }
+      }
+    },
+  },
+}
+</script>
+
+<style scoped></style>

--- a/src/styles/_site.css
+++ b/src/styles/_site.css
@@ -91,7 +91,9 @@ label {
   border-radius: 10rem;
   padding: 0.375rem 0.75rem;
 }
-
+.btn {
+  border-radius: 10px;
+}
 .btn-toolbar {
   justify-content: center;
 }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/87503113/144467594-0025da37-9db9-4b01-ac87-9ddf63fb1466.png)

### Change network when a claim in the wrong network


- Added modal to allow change the network when trying to claim in the wrong network

### How to Test

- Config your `.env` file
- Run the server

#### Case 1

1. Run the server
```shell
$~ npm run serve
```

2. Click on claim in you transaction

__Expected Result__
- Should display Wrong Network modal


### Checklist
- [x] Lint is clean `npm run lint`
- [x] Prettier is passing `npm run prettier`
