### PR TITLE
Update tokenInfo WBTC wrong name

### DIFF
--- a/src/constants/tokensInfo.js
+++ b/src/constants/tokensInfo.js
@@ -146,7 +146,7 @@ export const TOKEN_UBI_INFO = {
 
 export const TOKEN_WBTC_INFO = {
   token: 'WBTC',
-  name: 'Wrapped Ethereum',
+  name: 'Wrapped BTC',
   typeId: 0,
   icon:
     'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599/logo.png',


### PR DESCRIPTION
Change WBTC name to Wrapped BTC as it should be https://etherscan.io/token/0x2260fac5e5542a773aa44fbcfedf7c193bc2c599
