### PR TITLE
Don't display pager when there are not enough elements to display

### DIFF
--- a/src/components/transactions/TransactionList.vue
+++ b/src/components/transactions/TransactionList.vue
@@ -44,7 +44,12 @@
           :side-block-number="sideBlockNumber"
         />
       </table>
-      <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
+      <div
+        v-if="totalPages !== 1"
+        class="btn-toolbar"
+        role="toolbar"
+        aria-label="Toolbar with button groups"
+      >
         <div class="btn-group mr-2 btn-group-sm" role="group" aria-label="First group">
           <button
             id="txn-previous"


### PR DESCRIPTION
### Don't display pager when there are not enough elements to display

When there are less than one page available, don't display pager at all.

### Description
Added v-if condition to div block with pager from transactions

### How to Test
- run web application (tokenbridge-ui)
- add 1 transaction and notice the pager not being displayed
- for further testing, add more than transactions (5+) and check the pager being displayed



__Expected Result__
![pager1](https://user-images.githubusercontent.com/100863009/158502058-d7b79ddb-7b63-44a6-977d-aa29defa375e.jpeg)
![pager2](https://user-images.githubusercontent.com/100863009/158502178-5da41c6a-a81c-4f68-a337-285686b85261.jpeg)

