### PR TITLE
Fixed error component to properly parse the HTML

### DIFF
--- a/src/components/crossForm/ErrorMsg.vue
+++ b/src/components/crossForm/ErrorMsg.vue
@@ -7,7 +7,7 @@
       role="alert"
     >
       <h4 class="alert-heading">Ups! there was an error</h4>
-      <p id="alert-danger-text">{{ error }}</p>
+      <p id="alert-danger-text" v-html="error"></p>
       <button type="button" class="close" aria-label="Close" @click="hide">
         <span aria-hidden="true">&times;</span>
       </button>


### PR DESCRIPTION
Was fixed the error message for when the user try to cross an amount below the minimum allowed for that token.
Ex: Try to cross from Kovan to RSK 0.001 LINK
Now the message it's properly parsing the HTML and showing a link to user to verify the transaction on kovan network.