### PR TITLE
Reset tokens when switching network gives an error.

### DIFF
--- a/src/components/transfer/Transfer.vue
+++ b/src/components/transfer/Transfer.vue
@@ -231,6 +231,7 @@ export default {
         this.currentNetwork = this.oldNetwork
         this.oldNetwork = null
       }
+      this.tokens = this.currentNetwork.tokens
     },
     percentage(newPercentage) {
       const percentage = newPercentage / 100


### PR DESCRIPTION
### Reset tokens when switching network gives an error.

Fixes bug GBI-813 on Backlog: "Origin token list changed after refusing network switching".

### Description

This PR fixes a bug where when the user selects a different network from the dropdown, but rejects switching the network on the wallet, the list of tokens is still changed to the tokens that belong to the rejected network.

### How to Test

- Config your `.env` file
- Run the server

#### Case 1

1. Run the server
- On origin form, change the origin network to another valid network (RSK testnet or kovan)
- On metamask popup for network switching, refuse the new network connection
- Observe the origin form token list

### Checklist
- [] Lint is clean `npm run lint`
- [] Prettier is passing `npm run prettier`
