### PR TITLE
Fixed edge case

### DIFF
--- a/src/components/crossForm/CrossForm.vue
+++ b/src/components/crossForm/CrossForm.vue
@@ -560,7 +560,7 @@ export default {
           gas: 70_000,
         })
         console.info(receipt)
-        this.hasAllowance = true
+        await this.hasAllowanceCheck();
         this.showSpinner = false
       } catch (error) {
         this.hasAllowance = false


### PR DESCRIPTION
was fixed this edge case founded by Javier.

1. the user types 5UDST as the amount to cross
2. the clicks on approve button 
3. on metamask, edits the custom limit to 1USDT
4. waits for the tx to succeed, then, since ‘5USDT’ is still written  on the amount field, the user can click on cross even though he can just cross 1UDST