### PR TITLE
[GBI-814] - Sync status of claimed tx on both lists

### DIFF
--- a/src/components/transactions/SearchTransaction.vue
+++ b/src/components/transactions/SearchTransaction.vue
@@ -85,6 +85,7 @@
           :transactions="[transaction]"
           :rsk-block-number="rskBlockNumber"
           :side-block-number="sideBlockNumber"
+          :claimed="claimed"
         />
       </table>
     </div>
@@ -136,6 +137,9 @@ export default {
     sideBlockNumber: {
       type: Number,
       required: true,
+    },
+    claimed: {
+      type: Boolean,
     },
   },
   emits: ['onSearchTransaction'],

--- a/src/components/transactions/TransactionList.vue
+++ b/src/components/transactions/TransactionList.vue
@@ -42,6 +42,7 @@
           :transactions="transactions"
           :rsk-block-number="rskBlockNumber"
           :side-block-number="sideBlockNumber"
+          :emit-claim="emitClaim"
         />
       </table>
       <div
@@ -123,7 +124,7 @@ export default {
       default: 0,
     },
   },
-  emits: ['changePagination', 'changeLimit'],
+  emits: ['changePagination', 'changeLimit', 'onSuccessClaim'],
   data() {
     return {
       sharedState: store.state,
@@ -162,6 +163,9 @@ export default {
         this.offset = 0
       }
       this.$emit('changePagination', { limit: this.limit, offset: this.offset })
+    },
+    emitClaim() {
+      this.$emit('onSuccessClaim', true)
     },
   },
 }

--- a/src/components/transactions/Transactions.vue
+++ b/src/components/transactions/Transactions.vue
@@ -9,6 +9,7 @@
       :side-fed-members="sideFedMembers"
       :rsk-block-number="rskBlockNumber"
       :side-block-number="sideBlockNumber"
+      :claimed="claimed"
       @onSearchTransaction="handleOnSearchTransaction"
     />
     <TransactionList
@@ -24,6 +25,7 @@
       :total-transactions="totalTransactions"
       @changePagination="changePagination"
       @changeLimit="changeLimit"
+      @onSuccessClaim="handleSuccessClaim"
     />
   </div>
 </template>
@@ -67,7 +69,12 @@ export default {
       type: Object,
       default: null,
     },
+    claimLoading: {
+      type: Boolean,
+      default: false,
+    },
   },
+  emits: ['onSearchTransaction'],
   data() {
     return {
       sharedState: store.state,
@@ -77,6 +84,7 @@ export default {
       pollingBlockNumber: null,
       limit: 5,
       totalTransactions: 0,
+      claimed: false,
     }
   },
   computed: {
@@ -116,6 +124,9 @@ export default {
     clearInterval(this.pollingBlockNumber)
   },
   methods: {
+    handleSuccessClaim() {
+      this.claimed = true
+    },
     handleOnSearchTransaction() {
       this.refreshTransactions({ limit: this.limit, offset: 0 })
     },

--- a/src/components/transactions/mixins/TransactionRowMixin.js
+++ b/src/components/transactions/mixins/TransactionRowMixin.js
@@ -51,7 +51,15 @@ export default {
       type: Array,
       required: true,
     },
+    emitClaim: {
+      type: Function,
+    },
+    claimed: {
+      type: Boolean,
+      default: false,
+    },
   },
+  emits: ['onSuccessClaim'],
   data() {
     return {
       sharedState: store.state,
@@ -176,6 +184,11 @@ export default {
       this.error = ''
       this.refreshStep().then(() => {})
     },
+    claimed() {
+      if (this.claimed) {
+        this.currentStep = this.steps.Claimed
+      }
+    },
   },
   async created() {
     await this.refreshStep()
@@ -292,10 +305,13 @@ export default {
           data.loading = false
           data.error = ''
           data.showResultModal = true
-          await this.$services.TransactionService.saveTransaction({
+          const savedtx = await this.$services.TransactionService.saveTransaction({
             ...data.transaction,
             currentStep: data.currentStep,
           })
+
+          data.loading = false
+          this.emitClaim(savedtx)
         }
       } catch (error) {
         data.loading = false

--- a/src/components/transactions/mixins/TransactionTableMixin.js
+++ b/src/components/transactions/mixins/TransactionTableMixin.js
@@ -32,5 +32,12 @@ export default {
       type: Number,
       required: true,
     },
+    claimed: {
+      type: Boolean,
+      default: false,
+    },
+    emitClaim: {
+      type: Function,
+    },
   },
 }

--- a/src/components/transactions/transactionsTables/ERC20Table/ERC20TransactionRow.vue
+++ b/src/components/transactions/transactionsTables/ERC20Table/ERC20TransactionRow.vue
@@ -99,5 +99,6 @@ import TransactionRowMixin from '@/components/transactions/mixins/TransactionRow
 export default {
   name: 'ERC20TransactionRow',
   mixins: [TransactionRowMixin],
+  emits: ['onSuccessClaim'],
 }
 </script>

--- a/src/components/transactions/transactionsTables/ERC20Table/ERC20TransactionTable.vue
+++ b/src/components/transactions/transactionsTables/ERC20Table/ERC20TransactionTable.vue
@@ -1,4 +1,5 @@
 <template>
+  <h3>claimed on erc20 tx table: {{ claimed }}</h3>
   <thead>
     <tr>
       <th scope="col">Action</th>
@@ -24,6 +25,8 @@
       :side-block-number="sideBlockNumber"
       :rsk-fed-members="rskFedMembers"
       :side-fed-members="sideFedMembers"
+      :emit-claim="emitClaim"
+      :claimed="claimed"
     />
   </tbody>
 </template>


### PR DESCRIPTION
### [GBI-814] - Sync status of claimed tx on both lists

claimed transaction does not update its status on historic results list when claimed through found results

### Description

- added extra prop to track if a tx was claimed
- sync with both lists

### How to Test

- The user performs a valid cross tx on any supported network
- The user navigates to 'Transactions' section
- The user searches the transaction by its hash code on the destination network
- The user claims the transaction from the results (upper cross tx list)

- [] Search TX and listed TX have same status
